### PR TITLE
fix: PR#74

### DIFF
--- a/VMware.CloudFoundation.Reporting.psm1
+++ b/VMware.CloudFoundation.Reporting.psm1
@@ -2986,7 +2986,7 @@ Function Request-NsxtEdgeUserExpiry {
                                     if (($vcfNsxEdgeDetails = Get-VCFEdgeCluster | Where-Object { $_.nsxtCluster.vipFQDN -eq $vcfNsxDetails.fqdn })) {
                                         $customObject = New-Object System.Collections.ArrayList
                                         foreach ($nsxtEdgeNode in $vcfNsxEdgeDetails.edgeNodes) {
-                                            $rootPass = (Get-VCFCredential | Where-Object { $_.credentialType -eq 'SSH' -and $_.resource.resourceName -eq $vcfNsxDetails.fqdn -and $_.resource.domainName -eq $domain }).password
+                                            $rootPass = (Get-VCFCredential | Where-Object { $_.credentialType -eq 'SSH' -and $_.resource.resourceName -eq $nsxtEdgeNode.hostname -and $_.resource.domainName -eq $domain }).password
                                             $elementObject = Request-LocalUserExpiry -fqdn $nsxtEdgeNode.hostname -component 'NSX Edge' -rootPass $rootPass -checkUser admin
                                             if ($PsBoundParameters.ContainsKey('failureOnly')) {
                                                 if (($elementObject.alert -eq 'RED') -or ($elementObject.alert -eq 'YELLOW')) {


### PR DESCRIPTION
<!--
    Please provide a clear and concise description of the pull request.
-->
**Summary of Pull Request**
Fixing issue: [#74 - Request-NsxtEdgeUserExpiry function does not work if NSX Edge root password is different from NSX Manager root password ](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/issues/74)

Fixed function to use the correct variable (FQDN) in order to get NSX Edge password 

Signed-off-by: Ivaylo Ivanov <iivanov@vmware.com>
**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: [74](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/issues/74)

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
